### PR TITLE
Add CL2 usage and daily supply controlled columns to bill history

### DIFF
--- a/backend/bills.py
+++ b/backend/bills.py
@@ -26,7 +26,9 @@ Return this exact JSON structure:
   "offpeak_rate_cents": null,
   "shoulder_rate_cents": null,
   "controlled_load_rate_cents": null,
+  "controlled_load_2_kwh": null,
   "daily_supply_charge_cents": 100.00,
+  "daily_supply_controlled_cents": null,
   "total_amount_dollars": 150.00,
   "avg_daily_usage_kwh": 12.5,
   "avg_daily_cost_dollars": 5.50
@@ -35,6 +37,8 @@ Return this exact JSON structure:
 Notes:
 - Rates should be in cents per kWh
 - Daily supply charge in cents per day
+- controlled_load_2_kwh: total kWh used on Controlled Load 2 tariff (hot water etc), null if not present
+- daily_supply_controlled_cents: daily supply charge for controlled load circuit in cents per day, null if not present
 - If avg daily values aren't on the bill, calculate them from the billing period
 - For flat rate tariffs, put the single rate in peak_rate_cents
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -28,4 +28,6 @@ class BillData(BaseModel):
     avg_daily_usage_kwh: float
     avg_daily_cost_dollars: float
     controlled_load_rate_cents: Optional[float] = None
+    controlled_load_2_kwh: Optional[float] = None
+    daily_supply_controlled_cents: Optional[float] = None
     uploaded_at: Optional[str] = None

--- a/frontend/src/components/BillsList.jsx
+++ b/frontend/src/components/BillsList.jsx
@@ -1,6 +1,12 @@
 import { useState } from 'react'
 import { billsApi } from '../api'
 
+const Cell = ({ value, unit = '', fallback = '—', className = '' }) => (
+  <td className={`px-3 py-3 text-sm text-slate-300 ${className}`}>
+    {value != null ? `${value}${unit}` : <span className="text-slate-600">{fallback}</span>}
+  </td>
+)
+
 export default function BillsList({ bills, onDeleted }) {
   const [deleting, setDeleting] = useState(null)
 
@@ -26,35 +32,50 @@ export default function BillsList({ bills, onDeleted }) {
   return (
     <div className="glass rounded-2xl p-6">
       <h3 className="text-white font-semibold mb-4">Bill History</h3>
-      <div className="space-y-3">
-        {bills.map(bill => (
-          <div key={bill.id} className="bg-slate-800/60 rounded-xl p-4 flex items-center justify-between">
-            <div className="flex-1">
-              <div className="flex items-center gap-3 mb-1">
-                <span className="text-white font-medium">{bill.retailer}</span>
-                <span className="text-xs text-slate-500 bg-slate-700 px-2 py-0.5 rounded-full">
-                  {bill.billing_period_start} → {bill.billing_period_end}
-                </span>
-              </div>
-              <div className="flex gap-4 text-sm text-slate-400">
-                <span>{bill.total_kwh} kWh</span>
-                <span>{bill.peak_rate_cents} c/kWh</span>
-                <span>{bill.daily_supply_charge_cents} c/day supply</span>
-              </div>
-            </div>
-            <div className="flex items-center gap-4 ml-4">
-              <span className="text-amber-400 font-bold">${bill.total_amount_dollars?.toFixed(2)}</span>
-              <button
-                onClick={() => handleDelete(bill.id)}
-                disabled={deleting === bill.id}
-                className="text-slate-600 hover:text-red-400 transition text-lg disabled:opacity-30"
-                title="Delete bill"
-              >
-                ×
-              </button>
-            </div>
-          </div>
-        ))}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-slate-400 border-b border-slate-700">
+              <th className="px-3 py-2 font-medium">Retailer</th>
+              <th className="px-3 py-2 font-medium">Period</th>
+              <th className="px-3 py-2 font-medium">Total kWh</th>
+              <th className="px-3 py-2 font-medium">CL2 Usage</th>
+              <th className="px-3 py-2 font-medium">Daily Supply</th>
+              <th className="px-3 py-2 font-medium">Daily Supply CL</th>
+              <th className="px-3 py-2 font-medium">Total</th>
+              <th className="px-3 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {bills.map(bill => (
+              <tr key={bill.id} className="border-b border-slate-800 hover:bg-slate-800/40 transition">
+                <td className="px-3 py-3">
+                  <span className="text-white font-medium">{bill.retailer}</span>
+                </td>
+                <td className="px-3 py-3 text-slate-400 text-xs whitespace-nowrap">
+                  {bill.billing_period_start}<br />{bill.billing_period_end}
+                </td>
+                <Cell value={bill.total_kwh} unit=" kWh" />
+                <Cell value={bill.controlled_load_2_kwh} unit=" kWh" />
+                <Cell value={bill.daily_supply_charge_cents} unit=" c/day" />
+                <Cell value={bill.daily_supply_controlled_cents} unit=" c/day" />
+                <td className="px-3 py-3 text-amber-400 font-bold">
+                  ${bill.total_amount_dollars?.toFixed(2)}
+                </td>
+                <td className="px-3 py-3">
+                  <button
+                    onClick={() => handleDelete(bill.id)}
+                    disabled={deleting === bill.id}
+                    className="text-slate-600 hover:text-red-400 transition text-lg disabled:opacity-30"
+                    title="Delete bill"
+                  >
+                    ×
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   )


### PR DESCRIPTION
Adds Controlled Load 2 usage (kWh), daily supply, and daily supply controlled columns to the bill history table. Also updates Claude extraction prompt to pull these fields from PDFs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012MkWvajfojkd8QBXmDXoRE)_